### PR TITLE
Change three.js peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-dragcontrols",
-  "version": "0.88.1",
+  "version": "0.88.2",
   "description": "three.js DragControls",
   "main": "lib/index.js",
   "jsnext:main": "lib/index.module.js",
@@ -23,6 +23,6 @@
   "author": "keqingrong <keqingrong1992@gmail.com> (https://keqingrong.github.io/)",
   "license": "MIT",
   "peerDependencies": {
-    "three": "~0.88.0"
+    "three": ">= 0.86 <= 1.0"
   }
 }


### PR DESCRIPTION
This library can work with multiple three.js versions so there is no need to restrict versions unless breaking changes will be introduced.

I want to propose to make peerDependency more flexible so developer can decide which version should be used. Strict version conflicts with other three.js libs which have their own peerDependencies.